### PR TITLE
feat: Add REST APIs for placing orders, fetching all/user orders, and updating order status

### DIFF
--- a/src/main/java/com/payal/ecom/controller/admin/AdminOrderController.java
+++ b/src/main/java/com/payal/ecom/controller/admin/AdminOrderController.java
@@ -1,0 +1,36 @@
+package com.payal.ecom.controller.admin;
+
+
+import com.payal.ecom.dto.OrderDto;
+import com.payal.ecom.services.admin.adminOrder.AdminOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminOrderController {
+
+    private final AdminOrderService adminOrderService;
+
+    @GetMapping("/placeOrders")
+    public ResponseEntity<List<OrderDto>> getAllPlaceOrders(){
+        return ResponseEntity.ok(adminOrderService.getAllPlaceOrders());
+    }
+
+    @GetMapping("/order/{orderId}/{status}")
+    public ResponseEntity<?> changeOrderStatus(@PathVariable Long orderId, @PathVariable String status){
+        OrderDto orderDto = adminOrderService.changeOrderStatus(orderId, status);
+        if(orderDto == null){
+            return new ResponseEntity<>("Something went wrong!", HttpStatus.BAD_REQUEST);
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(orderDto);
+    }
+}

--- a/src/main/java/com/payal/ecom/controller/customer/CartController.java
+++ b/src/main/java/com/payal/ecom/controller/customer/CartController.java
@@ -3,6 +3,7 @@ package com.payal.ecom.controller.customer;
 
 import com.payal.ecom.dto.AddProductInCartDto;
 import com.payal.ecom.dto.OrderDto;
+import com.payal.ecom.dto.PlaceOrderDto;
 import com.payal.ecom.exceptions.ValidationException;
 import com.payal.ecom.services.customer.cart.CartService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/customer")
@@ -58,6 +61,18 @@ public class CartController {
     public ResponseEntity<OrderDto> removeProductFromCart(@RequestBody AddProductInCartDto addProductInCartDto) {
         return ResponseEntity.ok(cartService.removeProductFromCart(addProductInCartDto));
     }
+
+    @PostMapping("/placeOrder")
+    public ResponseEntity<OrderDto> placeOrder(@RequestBody PlaceOrderDto placeOrderDto ){
+        return ResponseEntity.status(HttpStatus.CREATED).body(cartService.placeOrder(placeOrderDto));
+    }
+
+    @GetMapping("/myOrders/{userId}")
+    public ResponseEntity<List<OrderDto>> getMyPlacedOrders(@PathVariable Long userId ){
+        return ResponseEntity.ok(cartService.getMyPlacedOrders(userId));
+    }
+
+
 
 
 

--- a/src/main/java/com/payal/ecom/dto/PlaceOrderDto.java
+++ b/src/main/java/com/payal/ecom/dto/PlaceOrderDto.java
@@ -1,0 +1,14 @@
+package com.payal.ecom.dto;
+
+
+import lombok.Data;
+
+@Data
+public class PlaceOrderDto {
+
+    private Long userId;
+
+    private String address;
+
+    private String orderDescription;
+}

--- a/src/main/java/com/payal/ecom/entity/Order.java
+++ b/src/main/java/com/payal/ecom/entity/Order.java
@@ -61,6 +61,7 @@ public class Order {
         orderDto.setOrderDescription(orderDescription);
         orderDto.setAddress(address);
         orderDto.setTrackingId(trackingId);
+        orderDto.setTotalAmount(totalAmount);
         orderDto.setAmount(amount);
         orderDto.setDate(date);
         orderDto.setOrderStatus(orderStatus);

--- a/src/main/java/com/payal/ecom/repository/OrderRepository.java
+++ b/src/main/java/com/payal/ecom/repository/OrderRepository.java
@@ -5,9 +5,15 @@ import com.payal.ecom.enums.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 
 public interface OrderRepository extends JpaRepository<Order,Long> {
 
     Order findByUserIdAndOrderStatus(Long userId, OrderStatus orderStatus);
+
+    List<Order> findAllByOrderStatusIn(List<OrderStatus> orderStatusList);
+
+    List<Order> findByUserIdAndOrderStatusIn(Long userId, List<OrderStatus> orderStatus);
 }

--- a/src/main/java/com/payal/ecom/services/admin/adminOrder/AdminOrderService.java
+++ b/src/main/java/com/payal/ecom/services/admin/adminOrder/AdminOrderService.java
@@ -1,0 +1,12 @@
+package com.payal.ecom.services.admin.adminOrder;
+
+import com.payal.ecom.dto.OrderDto;
+
+import java.util.List;
+
+public interface AdminOrderService {
+
+    List<OrderDto> getAllPlaceOrders();
+
+    OrderDto changeOrderStatus(Long orderId, String status);
+}

--- a/src/main/java/com/payal/ecom/services/admin/adminOrder/AdminOrderServiceImpl.java
+++ b/src/main/java/com/payal/ecom/services/admin/adminOrder/AdminOrderServiceImpl.java
@@ -1,0 +1,49 @@
+package com.payal.ecom.services.admin.adminOrder;
+
+import com.payal.ecom.dto.OrderDto;
+import com.payal.ecom.entity.Order;
+import com.payal.ecom.enums.OrderStatus;
+import com.payal.ecom.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminOrderServiceImpl implements AdminOrderService {
+
+    private final OrderRepository orderRepository;
+
+    public List<OrderDto> getAllPlaceOrders(){
+
+        List<Order> orderList = orderRepository.
+                findAllByOrderStatusIn(List.of(OrderStatus.Placed, OrderStatus.Shipped, OrderStatus.Delivered));
+
+        return orderList
+                .stream()
+                .map(Order::getOrderDto)
+                .collect(Collectors.toList());
+    }
+
+    public  OrderDto changeOrderStatus(Long orderId, String status){
+        Optional<Order> optionalOrder = orderRepository.findById(orderId);
+        if(optionalOrder.isPresent()){
+            Order order = optionalOrder.get();
+
+            if(Objects.equals(status,"Shipped")){
+                order.setOrderStatus(OrderStatus.Shipped);
+            }else if(Objects.equals(status,"Delivered")){
+                order.setOrderStatus(OrderStatus.Delivered);
+            }
+
+            return orderRepository.save(order).getOrderDto();
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/payal/ecom/services/customer/cart/CartService.java
+++ b/src/main/java/com/payal/ecom/services/customer/cart/CartService.java
@@ -2,7 +2,10 @@ package com.payal.ecom.services.customer.cart;
 
 import com.payal.ecom.dto.AddProductInCartDto;
 import com.payal.ecom.dto.OrderDto;
+import com.payal.ecom.dto.PlaceOrderDto;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public interface CartService {
 
@@ -17,6 +20,10 @@ public interface CartService {
     OrderDto decreaseProductQuantity(AddProductInCartDto addProductInCartDto);
 
     OrderDto removeProductFromCart(AddProductInCartDto addProductInCartDto);
+
+    OrderDto placeOrder(PlaceOrderDto placeOrderDto);
+
+    List<OrderDto> getMyPlacedOrders(Long userId);
 
 
 }


### PR DESCRIPTION
feat(api): Add REST APIs for placing orders, retrieving orders, and updating status

- Added POST /orders/place endpoint to save orders with address, items, coupon, and user info
- Implemented GET /orders to fetch all orders for admin view
- Created GET /orders/user/{id} to fetch user-specific orders for history page
- Added PUT /orders/{id}/status endpoint to update order status (e.g., Placed, Shipped, Delivered)
- Refactored service layer to handle user-based filtering and DTO mapping
- Validated input payloads and handled null-safe edge cases like cartItems and couponName
